### PR TITLE
remove a redundant PRIxPTR from sprintf

### DIFF
--- a/stack_trace.cpp
+++ b/stack_trace.cpp
@@ -34,7 +34,7 @@ int __attribute__((noinline)) backtrace(char* stacks[], int stack_len) {
     if (p == NULL) {
         return n;
     }
-    sprintf(p, "#%-2d" PRIxPTR "%s + 0x%" PRIxPTR "\n",
+    sprintf(p, "#%-2d %s + 0x%" PRIxPTR "\n",
         n,
         name,
         static_cast<uintptr_t>(off));


### PR DESCRIPTION
A little fix only.

Q1. malloc_hook & free_hook 里面的 save_hook() / set_hook() 有何作用?

Q2. __malloc_hook & __free_hook 貌似被 deprecated 了，我用 GCC 5.4 编译会有很多 warning.

Q3. 为何 space 和 tab 混用？